### PR TITLE
Build OSX with Cmake

### DIFF
--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,0 +1,62 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost_cpp:
+- 1.70.0
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fftw:
+- '3'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+netcdf_fortran:
+- '4.5'
+numpy:
+- '1.14'
+perl:
+- 5.26.2
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  fftw:
+    max_pin: x
+  netcdf-fortran:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+python:
+- '3.6'
+readline:
+- '8.0'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,0 +1,62 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost_cpp:
+- 1.70.0
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fftw:
+- '3'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+netcdf_fortran:
+- '4.5'
+numpy:
+- '1.14'
+perl:
+- 5.26.2
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  fftw:
+    max_pin: x
+  netcdf-fortran:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+python:
+- '3.7'
+readline:
+- '8.0'
+zlib:
+- '1.2'

--- a/.ci_support/osx_python3.8.yaml
+++ b/.ci_support/osx_python3.8.yaml
@@ -1,0 +1,62 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost_cpp:
+- 1.70.0
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+fftw:
+- '3'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+netcdf_fortran:
+- '4.5'
+numpy:
+- '1.14'
+perl:
+- 5.26.2
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  fftw:
+    max_pin: x
+  netcdf-fortran:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+python:
+- '3.8'
+readline:
+- '8.0'
+zlib:
+- '1.2'

--- a/README.md
+++ b/README.md
@@ -82,16 +82,31 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
     </td>
   </tr>
   <tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,13 +14,12 @@ patch -p1 --ignore-whitespace -t -i amber19-fix-cmake.patch || true
 
 CMAKE_FLAGS=""
 if [[ "$target_platform" == osx* ]]; then
+    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
     # Hack around https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
     # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
-    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
-    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
-    # export FFLAGS="-isysroot ${CONDA_BUILD_SYSROOT} ${FFLAGS}"
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ if [[ "$target_platform" == osx* ]]; then
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
-    export FFLAGS="-isysroot ${CONDA_BUILD_SYSROOT} ${FFLAGS}"
+    # export FFLAGS="-isysroot ${CONDA_BUILD_SYSROOT} ${FFLAGS}"
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,12 +20,6 @@ if [[ "$target_platform" == osx* ]]; then
     # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
-    # # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
-    # set +eux
-    # conda remove -p ${PREFIX} --force tk
-    # conda install -p ${PREFIX} --force-reinstall --clobber --yes \
-    #               xorg-libxt xorg-libxext xorg-libx11
-    # set -eux
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,8 +21,10 @@ if [[ "$target_platform" == osx* ]]; then
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
+    set +u
     conda remove -p ${PREFIX} --force --yes tk
     conda install -p ${PREFIX} --force --yes xorg-libxt xorg-libxext xorg-libx11
+    set -u
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,10 @@ patch -p1 --ignore-whitespace -t -i amber19-fix-cmake.patch || true
 
 CMAKE_FLAGS=""
 if [[ "$target_platform" == osx* ]]; then
+    # Hack around https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
+    # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
+    # See contents of fake-bin/cc1 for an explanation
+    export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
     export FFLAGS="-isysroot ${CONDA_BUILD_SYSROOT} ${FFLAGS}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,9 @@ if [[ "$target_platform" == osx* ]]; then
     # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
+    # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
+    conda remove -p ${PREFIX} --force --yes tk
+    conda install -p ${PREFIX} --force --yes xorg-libxt xorg-libxext xorg-libx11
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,9 +13,11 @@ perl -pi -e 's/\r$//g' ${SRC_DIR}/cmake/*.cmake
 patch -p1 --ignore-whitespace -t -i amber19-fix-cmake.patch || true
 
 CMAKE_FLAGS=""
+BUILD_GUI="TRUE"
 if [[ "$target_platform" == osx* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+    BUILD_GUI="FALSE"
     # Hack around https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
     # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
     # See contents of fake-bin/cc1 for an explanation
@@ -30,7 +32,7 @@ cmake ${SRC_DIR} ${CMAKE_FLAGS} \
     -DCOMPILER=MANUAL \
     -DPYTHON_EXECUTABLE=${PYTHON} \
     -DDOWNLOAD_MINICONDA=FALSE \
-    -DBUILD_GUI=TRUE \
+    -DBUILD_GUI=${BUILD_GUI} \
     -DCHECK_UPDATES=FALSE
 
 make && make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,7 +21,10 @@ if [[ "$target_platform" == osx* ]]; then
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
-    conda install -p ${PREFIX} --force --yes xorg-libxt xorg-libxext xorg-libx11
+    set +eux
+    conda install -p ${PREFIX} --force-reinstall --clobber --yes \
+                  xorg-libxt xorg-libxext xorg-libx11
+    set -eux
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,6 +22,7 @@ if [[ "$target_platform" == osx* ]]; then
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
     set +eux
+    conda remove -p ${PREFIX} tk
     conda install -p ${PREFIX} --force-reinstall --clobber --yes \
                   xorg-libxt xorg-libxext xorg-libx11
     set -eux

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,10 +21,7 @@ if [[ "$target_platform" == osx* ]]; then
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
     # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
-    set +u
-    conda remove -p ${PREFIX} --force --yes tk
     conda install -p ${PREFIX} --force --yes xorg-libxt xorg-libxext xorg-libx11
-    set -u
 fi
 
 # Build AmberTools with cmake

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,12 +20,12 @@ if [[ "$target_platform" == osx* ]]; then
     # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
     # See contents of fake-bin/cc1 for an explanation
     export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
-    # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
-    set +eux
-    conda remove -p ${PREFIX} tk
-    conda install -p ${PREFIX} --force-reinstall --clobber --yes \
-                  xorg-libxt xorg-libxext xorg-libx11
-    set -eux
+    # # Workaround https://github.com/conda-forge/tk-feedstock/issues/15
+    # set +eux
+    # conda remove -p ${PREFIX} --force tk
+    # conda install -p ${PREFIX} --force-reinstall --clobber --yes \
+    #               xorg-libxt xorg-libxext xorg-libx11
+    # set -eux
 fi
 
 # Build AmberTools with cmake

--- a/recipe/fake-bin/cc1
+++ b/recipe/fake-bin/cc1
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+###
+# Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
+###
+
+# Detecting flags from gfortran which is backed by clang fails with
+#     x86_64-apple-darwin13.4.0-gfortran: error trying to exec 'cc1': execvp: No such file or directory
+# This comes from
+#     https://github.com/mesonbuild/meson/blob/61993f893bbdc2415155e28ee70e6ea806725e64/mesonbuild/environment.py#L668-L671
+# which runs
+#     x86_64-apple-darwin13.4.0-gfortran -E -dM -
+# Looking at the verbose output this is trying to run:
+#     cc1 -E -quiet -v -D__DYNAMIC__ - -fPIC -mmacosx-version-min=10.9 -mtune=generic -dM
+# The -quiet argument must be removed from the arguments as this isn't supported by clang
+# Adding this file to PATH hacks around these issues
+
+# Already reported at: https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
+
+ARGS=()
+for var in "$@"; do
+    # Ignore known bad arguments
+    [ "$var" != '-quiet' ] && ARGS+=("$var")
+done
+
+"$CC" "${ARGS[@]}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,8 @@ requirements:
     - pthread-stubs
     - fftw
     - liblapack
-    - xorg-libxt  # [linux]
-    - xorg-libxext  # [linux]
+    - xorg-libxt
+    - xorg-libxext
     - xorg-libx11  # [linux]
     - readline
   run:
@@ -73,8 +73,8 @@ requirements:
     - libblas
     - liblapack
     - libopenblas
-    - xorg-libxt  # [linux]
-    - xorg-libxext  # [linux]
+    - xorg-libxt
+    - xorg-libxext
     - xorg-libx11  # [linux]
     - readline
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,8 @@ requirements:
     - pthread-stubs
     - fftw
     - liblapack
-    - xorg-libxt
-    - xorg-libxext
+    - xorg-libxt  # [linux]
+    - xorg-libxext   # [linux]
     - readline
   run:
     - python
@@ -71,8 +71,8 @@ requirements:
     - fftw
     - libblas
     - liblapack
-    - xorg-libxt
-    - xorg-libxext
+    - xorg-libxt  # [linux]
+    - xorg-libxext  # [linux]
     - readline
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     # - patches/amber19-fix-cmake.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/do_not_override_osx_deployment_target.patch  # [osx]
     # Fix weird bug described here:
     #   https://github.com/conda-forge/ambertools-feedstock/pull/11#issuecomment-570618741
-    - patches/comment_out_xdrfile_version.patch  # [osx]
+    - patches/delete_xdrfile_version.patch  # [osx]
     # The following patch was downloaded from this GH issue:
     #   https://github.com/Amber-MD/cmake-buildscripts/issues/131#issuecomment-561280272
     # It needs to be applied manually in build.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,6 @@ requirements:
     - liblapack
     - xorg-libxt
     - xorg-libxext
-    - xorg-libx11  # [linux]
     - readline
   run:
     - python
@@ -75,7 +74,6 @@ requirements:
     - libopenblas
     - xorg-libxt
     - xorg-libxext
-    - xorg-libx11  # [linux]
     - readline
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - patches/do_not_use_global_conda_prefix.patch
     - patches/do_not_symlink_missing_ff12pol.patch
     - patches/use_external_netcdf.patch
+    - patches/do_not_override_osx_deployment_target.patch
     # The following patch was downloaded from this GH issue:
     #   https://github.com/Amber-MD/cmake-buildscripts/issues/131#issuecomment-561280272
     # It needs to be applied manually in build.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or py2k or osx]
+  skip: True  # [win or py2k]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,10 @@ source:
     - patches/do_not_use_global_conda_prefix.patch
     - patches/do_not_symlink_missing_ff12pol.patch
     - patches/use_external_netcdf.patch
-    - patches/do_not_override_osx_deployment_target.patch
+    - patches/do_not_override_osx_deployment_target.patch  # [osx]
+    # Fix weird bug described here:
+    #   https://github.com/conda-forge/ambertools-feedstock/pull/11#issuecomment-570618741
+    - patches/comment_out_xdrfile_version.patch  # [osx]
     # The following patch was downloaded from this GH issue:
     #   https://github.com/Amber-MD/cmake-buildscripts/issues/131#issuecomment-561280272
     # It needs to be applied manually in build.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,6 @@ requirements:
     - fftw
     - libblas
     - liblapack
-    - libopenblas
     - xorg-libxt
     - xorg-libxext
     - readline

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,9 +56,9 @@ requirements:
     - pthread-stubs
     - fftw
     - liblapack
-    - xorg-libxt
-    - xorg-libxext
-    - xorg-libx11
+    - xorg-libxt  # [linux]
+    - xorg-libxext  # [linux]
+    - xorg-libx11  # [linux]
     - readline
   run:
     - python
@@ -73,9 +73,9 @@ requirements:
     - libblas
     - liblapack
     - libopenblas
-    - xorg-libxt
-    - xorg-libxext
-    - xorg-libx11
+    - xorg-libxt  # [linux]
+    - xorg-libxext  # [linux]
+    - xorg-libx11  # [linux]
     - readline
 
 test:

--- a/recipe/patches/comment_out_xdrfile_version.patch
+++ b/recipe/patches/comment_out_xdrfile_version.patch
@@ -1,0 +1,7 @@
+diff --git a/AmberTools/src/cpptraj/src/xdrfile/VERSION b/AmberTools/src/cpptraj/src/xdrfile/VERSION
+index 8926873d..213b6891 100644
+--- a/AmberTools/src/cpptraj/src/xdrfile/VERSION
++++ b/AmberTools/src/cpptraj/src/xdrfile/VERSION
+@@ -1 +1 @@
+-Code is from MDTRAJ (https://github.com/mdtraj/mdtraj), commit aa1c91f3ab6b0f9e9f1d0c790d2b5bff7c83ece4
++// Code is from MDTRAJ (https://github.com/mdtraj/mdtraj), commit aa1c91f3ab6b0f9e9f1d0c790d2b5bff7c83ece4

--- a/recipe/patches/comment_out_xdrfile_version.patch
+++ b/recipe/patches/comment_out_xdrfile_version.patch
@@ -1,7 +1,0 @@
-diff --git a/AmberTools/src/cpptraj/src/xdrfile/VERSION b/AmberTools/src/cpptraj/src/xdrfile/VERSION
-index 8926873d..213b6891 100644
---- a/AmberTools/src/cpptraj/src/xdrfile/VERSION
-+++ b/AmberTools/src/cpptraj/src/xdrfile/VERSION
-@@ -1 +1 @@
--Code is from MDTRAJ (https://github.com/mdtraj/mdtraj), commit aa1c91f3ab6b0f9e9f1d0c790d2b5bff7c83ece4
-+// Code is from MDTRAJ (https://github.com/mdtraj/mdtraj), commit aa1c91f3ab6b0f9e9f1d0c790d2b5bff7c83ece4

--- a/recipe/patches/delete_xdrfile_version.patch
+++ b/recipe/patches/delete_xdrfile_version.patch
@@ -1,0 +1,7 @@
+diff --git a/AmberTools/src/cpptraj/src/xdrfile/VERSION b/AmberTools/src/cpptraj/src/xdrfile/VERSION
+deleted file mode 100644
+index 8926873d..00000000
+--- a/AmberTools/src/cpptraj/src/xdrfile/VERSION
++++ /dev/null
+@@ -1 +0,0 @@
+-Code is from MDTRAJ (https://github.com/mdtraj/mdtraj), commit aa1c91f3ab6b0f9e9f1d0c790d2b5bff7c83ece4

--- a/recipe/patches/do_not_override_osx_deployment_target.patch
+++ b/recipe/patches/do_not_override_osx_deployment_target.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerFlags.cmake b/cmake/CompilerFlags.cmake
+index 914eddbb..b2ed5cf5 100644
+--- a/cmake/CompilerFlags.cmake
++++ b/cmake/CompilerFlags.cmake
+@@ -215,7 +215,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STR
+ 	if(TARGET_OSX)
+ 		# on OS X, Python will link pytraj's extension modules to libc++, so cpptraj needs to use the same standard library
+ 		add_flags(CXX -stdlib=libc++)
+-		set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
++		# set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
+ 	endif()	
+ 	
+ 	if(OPENMP AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.7))


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

# Changelog

* `gfortran` and `cmake` have a small issue in `osx` (submitted [here](https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11)). We are using a hack provided in [`dftd4`](https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4). Let's see if this works!
* `OSX_DEPLOYMENT_TARGET` was hardcoded to `10.7` for OSX+Clang. In `conda-forge` this must be `10.9`. A patch has been added to fix this.
* `tk` bundles some X11 libs in the `osx` package, clobbering our `xorg-*` dependencies. This is preventing us from building `Xleap` and other GUI-based components (although it did work on my local setup).
* `libopenblas` must not be included-
* `xdrfile/VERSION` has to be deleted so it doesn't interfere with the compilation process in `osx`.