### PR TITLE
No ambermini

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,28 +10,28 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_python3.6.____cpython:
+        CONFIG: linux_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7:
-        CONFIG: linux_python3.7
+      linux_python3.7.____cpython:
+        CONFIG: linux_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.8:
-        CONFIG: linux_python3.8
+      linux_python3.8.____cpython:
+        CONFIG: linux_python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_ppc64le_python3.6:
-        CONFIG: linux_ppc64le_python3.6
+      linux_ppc64le_python3.6.____cpython:
+        CONFIG: linux_ppc64le_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_python3.7:
-        CONFIG: linux_ppc64le_python3.7
+      linux_ppc64le_python3.7.____cpython:
+        CONFIG: linux_ppc64le_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_python3.8:
-        CONFIG: linux_ppc64le_python3.8
+      linux_ppc64le_python3.8.____cpython:
+        CONFIG: linux_ppc64le_python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,19 +5,19 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
     matrix:
-      osx_python3.6:
-        CONFIG: osx_python3.6
+      osx_python3.6.____cpython:
+        CONFIG: osx_python3.6.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_python3.7.____cpython:
+        CONFIG: osx_python3.7.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.8:
-        CONFIG: osx_python3.8
+      osx_python3.8.____cpython:
+        CONFIG: osx_python3.8.____cpython
         UPLOAD_PACKAGES: True
 
   steps:
@@ -48,7 +48,7 @@ jobs:
       source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
@@ -59,23 +59,23 @@ jobs:
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,25 +13,25 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '8'
 libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
-- '1.14'
+- '1.16'
 perl:
 - 5.26.2
 pin_run_as_build:
@@ -53,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
@@ -27,7 +27,7 @@ libblas:
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
@@ -53,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -1,41 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 boost_cpp:
 - '1.72'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '8'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '8'
 libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
-- '1.14'
+- '1.16'
 perl:
 - 5.26.2
 pin_run_as_build:
@@ -57,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.8.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/linux_python3.6.____cpython.yaml
+++ b/.ci_support/linux_python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,25 +13,25 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '7'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-comp7
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '8'
+- '7'
 libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
-- '1.16'
+- '1.14'
 perl:
 - 5.26.2
 pin_run_as_build:
@@ -53,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/linux_python3.7.____cpython.yaml
+++ b/.ci_support/linux_python3.7.____cpython.yaml
@@ -27,7 +27,7 @@ libblas:
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
@@ -53,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- 3.7.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/linux_python3.8.____cpython.yaml
+++ b/.ci_support/linux_python3.8.____cpython.yaml
@@ -1,21 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 boost_cpp:
 - '1.72'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 fftw:
 - '3'
 fortran_compiler:
@@ -27,11 +27,7 @@ libblas:
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- 4.7.4
 netcdf_fortran:
 - '4.5'
 numpy:
@@ -57,7 +53,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.8.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -1,21 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 boost_cpp:
 - '1.72'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
 fftw:
 - '3'
 fortran_compiler:
@@ -27,7 +27,11 @@ libblas:
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 netcdf_fortran:
 - '4.5'
 numpy:
@@ -53,7 +57,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.6.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -27,7 +27,7 @@ libblas:
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -57,7 +57,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- 3.7.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/.ci_support/osx_python3.8.____cpython.yaml
+++ b/.ci_support/osx_python3.8.____cpython.yaml
@@ -1,37 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 boost_cpp:
 - '1.72'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '8'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '8'
-docker_image:
-- condaforge/linux-anvil-ppc64le
+- '9'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '8'
+- '7'
 libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8.0 *netlib
 libnetcdf:
-- 4.7.3
+- 4.7.4
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 netcdf_fortran:
 - '4.5'
 numpy:
-- '1.16'
+- '1.14'
 perl:
 - 5.26.2
 pin_run_as_build:
@@ -53,7 +57,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- 3.8.* *_cpython
 readline:
 - '8.0'
 zlib:

--- a/README.md
+++ b/README.md
@@ -34,66 +34,66 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_ppc64le_python3.6</td>
+              <td>linux_ppc64le_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.7</td>
+              <td>linux_ppc64le_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.8</td>
+              <td>linux_ppc64le_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6</td>
+              <td>linux_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7</td>
+              <td>linux_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.8</td>
+              <td>linux_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6</td>
+              <td>osx_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.7</td>
+              <td>osx_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.8</td>
+              <td>osx_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6854&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ambertools-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,16 +122,7 @@ test:
     - teLeap -h
     - tleap -h
   # This extra dependency SHOULD make the installation FAIL
-    - |
-      set +e
-      conda install -c omnia ambermini;
-      if [[ $? == 0 ]]; then
-        echo "This command should have FAILED!";
-        false;
-      else
-        true;
-      fi;
-      set -e
+    - conda install -c conda-forge -c omnia ambermini 2>&1 | tee | grep -q "PackagesNotFoundError"
   imports:
     - pytraj
     - parmed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,8 +121,6 @@ test:
     - sqm -h
     - teLeap -h
     - tleap -h
-  # This extra dependency SHOULD make the installation FAIL; remove later?
-    - conda install --yes omnia::ambermini ambertools>=19.10 || true
   imports:
     - pytraj
     - parmed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ source:
     # - patches/amber19-fix-cmake.patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,8 +121,8 @@ test:
     - sqm -h
     - teLeap -h
     - tleap -h
-  # This extra dependency SHOULD make the installation FAIL
-    - conda install --yes -c conda-forge -c omnia ambermini 2>&1 | tee | grep "PackagesNotFoundError"
+  # This extra dependency SHOULD make the installation FAIL; remove later?
+    - conda install --yes -c conda-forge -c omnia ambermini || true
   imports:
     - pytraj
     - parmed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ test:
     - teLeap -h
     - tleap -h
   # This extra dependency SHOULD make the installation FAIL; remove later?
-    - conda install --yes -c conda-forge -c omnia ambermini || true
+    - conda install --yes omnia::ambermini ambertools>=19.10 || true
   imports:
     - pytraj
     - parmed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ test:
     - teLeap -h
     - tleap -h
   # This extra dependency SHOULD make the installation FAIL
-    - conda install -c conda-forge -c omnia ambermini 2>&1 | tee | grep -q "PackagesNotFoundError"
+    - conda install --yes -c conda-forge -c omnia ambermini 2>&1 | tee | grep "PackagesNotFoundError"
   imports:
     - pytraj
     - parmed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,6 +94,8 @@ requirements:
     - readline
     - llvm-openmp  # [osx]
     - libgomp      # [linux and not aarch64]
+  run_constrained:
+    - ambermini ==9999999999
 
 test:
   requires:
@@ -119,6 +121,17 @@ test:
     - sqm -h
     - teLeap -h
     - tleap -h
+  # This extra dependency SHOULD make the installation FAIL
+    - |
+      set +e
+      conda install -c omnia ambermini;
+      if [[ $? == 0 ]]; then
+        echo "This command should have FAILED!";
+        false;
+      else
+        true;
+      fi;
+      set -e
   imports:
     - pytraj
     - parmed


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

`ambermini` used to be a minified distribution of `ambertools` used in some packages (specially in the `omnia` channel). This is incompatible with the full `ambertools` distribution so we are using the `run_constrained` trick to explicitly declare it as such instead of crossing our fingers :D 