### PR TITLE
Readd symlink patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ package:
 source:
   url: https://ambermd.org/downloads/AmberTools20jlmrcc.tar.bz2
   sha256: b1e1f8f277c54e88abc9f590e788bbb2f7a49bcff5e8d8a6eacfaf332a4890f9
+  patches:
+    - patches/do_not_symlink_missing_ff12pol.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py2k]
 
 requirements:

--- a/recipe/patches/do_not_symlink_missing_ff12pol.patch
+++ b/recipe/patches/do_not_symlink_missing_ff12pol.patch
@@ -1,11 +1,11 @@
 diff --git a/dat/CMakeLists.txt b/dat/CMakeLists.txt
-index ecfc5514..a822db5b 100644
+index ecfc55141d..a822db5b76 100644
 --- a/dat/CMakeLists.txt
 +++ b/dat/CMakeLists.txt
 @@ -3,6 +3,6 @@
-
+ 
  install(DIRECTORY . USE_SOURCE_PERMISSIONS DESTINATION ${DATADIR} COMPONENT Data)
-
+ 
 -if(NOT (HOST_WINDOWS OR TARGET_WINDOWS))
 -	installtime_create_symlink(${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12polL ${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12pol Data)
 -endif()

--- a/recipe/patches/do_not_symlink_missing_ff12pol.patch
+++ b/recipe/patches/do_not_symlink_missing_ff12pol.patch
@@ -1,0 +1,14 @@
+diff --git a/dat/CMakeLists.txt b/dat/CMakeLists.txt
+index ecfc5514..a822db5b 100644
+--- a/dat/CMakeLists.txt
++++ b/dat/CMakeLists.txt
+@@ -3,6 +3,6 @@
+
+ install(DIRECTORY . USE_SOURCE_PERMISSIONS DESTINATION ${DATADIR} COMPONENT Data)
+
+-if(NOT (HOST_WINDOWS OR TARGET_WINDOWS))
+-	installtime_create_symlink(${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12polL ${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12pol Data)
+-endif()
++# if(NOT (HOST_WINDOWS OR TARGET_WINDOWS))
++# 	installtime_create_symlink(${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12polL ${CMAKE_INSTALL_POSTFIX}dat/leap/cmd/leaprc.protein.ff12pol Data)
++# endif()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


I oversaw the missing symlink warning message, and this causes errors downstream if you try to use `constructor` to build a package depending on `ambertools`.