### PR TITLE
Update to 20.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "20.3" %}
+{% set version = "20.4" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ source:
     - patches/do_not_symlink_missing_ff12pol.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or py2k]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

```
update.4

Author: Scott Brozell

Date: June 4, 2020

Programs: LEaP and update_amber

Description: This addresses several issues:
  * Fixes a bug, reported by Hector A. Baldoni, wherein long bond length
    warning messages did not report the names of the bonded atoms.
  * Fixes related bugs wherein output messages were incomplete or incoherent.
  * Clarifies help messages in LEaP.
```