### PR TITLE
update to 20.12

### DIFF
--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -70,6 +70,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -70,6 +70,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -70,6 +70,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -70,6 +70,8 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "20.11" %}
+{% set version = "20.12" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

```
*******> update.12

Author: David Case

Date: December 17, 2020

Programs: nss, mdgx

Description: Some C code in AmberTools was not compliant with the C99
             standard.  Newer compilers, like clang on OSX 11, require
             this, at least by default.  This fixes that.

--------------------------------------------------------------------------------
 AmberTools/src/mdgx/IPolQ.c    |  1 +
 AmberTools/src/mdgx/Wrappers.c |  1 +
 AmberTools/src/nss/matgen.h    | 13 +++++++++++++
 AmberTools/src/nss/tss.c       |  3 ++-
 4 files changed, 17 insertions(+), 1 deletion(-)
```