### PR TITLE
Update to 21.5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ export CXXFLAGS="${CXXFLAGS} -pthread"
 # duplicate symbols cause errors on GCC10+ and Clang 11+
 # see https://github.com/conda-forge/ambertools-feedstock/pull/50#issuecomment-756171906
 # This will get fixed upstream at some point...
-if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2104 )); then
+if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2105 )); then
     export CFLAGS="${CFLAGS:-} -fcommon"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,8 @@ requirements:
     - cmake         # [not osx]
     - cmake 3.20.*  # [osx]
     - perl
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux and not aarch64]
+    # - llvm-openmp  # [osx]
+    # - libgomp      # [linux and not aarch64]
   host:
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "21.4" %}
+{% set version = "21.5" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://ambermd.org/bugfixes/AmberTools/21.0/update.5

```
*******> update.5

Author: David Case

Date: July 19, 2021

Programs: pdb4amber

Description: pdb4amber now creates a "_renum" file that includes the
             original chainID's as well as residue names and numbers.  This
             fix is required to handle blank chainID's in the input PDB
             file.  This is technically illegal, but nevertheless very common.
```