### PR TITLE
update to 21.8

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ export CXXFLAGS="${CXXFLAGS} -pthread"
 # duplicate symbols cause errors on GCC10+ and Clang 11+
 # see https://github.com/conda-forge/ambertools-feedstock/pull/50#issuecomment-756171906
 # This will get fixed upstream at some point...
-if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2107 )); then
+if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2108 )); then
     export CFLAGS="${CFLAGS:-} -fcommon"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "21.7" %}
+{% set version = "21.8" %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +16,7 @@ source:
     - patches/do_not_vendor_packmol.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or py2k]
   # Some binaries (e.g. nab) hardcode the path to the compiler in BUILD_PREFIX
   # which does not get replaced and causes errors on runtime


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://ambermd.org/bugfixes/AmberTools/21.0/update.8.
```
*******> update.8
  
Author: Charles Lin, Ido Ben-Shalom

Date: Sept 1, 2021

Programs: pmemd, pmemd.cuda updated mcmd test cases

Description: Adds mcwat test cases for pmemd and pmemd.cuda

--------------------------------------------------------------------------------

 test/cuda/mcwat/Run.mcwat                        |    5 +-
 test/cuda/mcwat/mdout.mcwat.GPU_DPFP             |  178 +--
 test/cuda/mcwat/mdout.mcwat.GPU_SPFP             |  178 +--
 test/mcwat/Run.mcwat                             |    5 +-
 test/mcwat/mdout.mcwat.save                      |  174 +-
 20 files changed, 2175 insertions(+), 1403 deletions(-)
```