### PR TITLE
update to 21.9

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ export CXXFLAGS="${CXXFLAGS} -pthread"
 # duplicate symbols cause errors on GCC10+ and Clang 11+
 # see https://github.com/conda-forge/ambertools-feedstock/pull/50#issuecomment-756171906
 # This will get fixed upstream at some point...
-if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2108 )); then
+if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2109 )); then
     export CFLAGS="${CFLAGS:-} -fcommon"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "21.8" %}
+{% set version = "21.9" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://ambermd.org/bugfixes/AmberTools/21.0/update.9

```
*******> update.9

Author: David Case

Date: September 13, 2021

Programs: sander

Description: Adds support for 3D-RISM calculations in sander for periodic
             systems, such as macromolecular crystals

--------------------------------------------------------------------------------
 AmberTools/src/parmed/setup.py                     |  2 +
 AmberTools/src/rism/mdiis_blas2_c.F90              | 14 ++--
 AmberTools/src/rism/mdiis_blas_c.F90               | 20 ++---
 AmberTools/src/rism/rism1d.F90                     |  9 +-
 AmberTools/src/rism/rism1d_c.F90                   | 29 ++++++-
 AmberTools/src/rism/rism1d_closure_c.F90           | 42 ++++++++--
 AmberTools/src/rism/rism3d_c.F90                   | 18 ++--
 AmberTools/src/rism/rism3d_hnc_c.F90               |  6 +-
 AmberTools/src/rism/rism3d_kh_c.F90                |  8 +-
 AmberTools/src/rism/rism3d_potential_c.F90         | 84 +++++++------------
 AmberTools/src/rism/rism3d_psen_c.F90              |  6 +-
 AmberTools/src/rism/rism3d_solvent_c.F90           | 36 ++++++--
 AmberTools/test/rism1d/check1d                     |  2 +-
 AmberTools/test/rism1d/spc-hnc/spc-lj.xvv.save     |  4 +
 AmberTools/test/rism1d/spc-kh/spc.xvv.save         |  4 +
 .../test/rism1d/spc-psen/spc-nacl-3.xvv.save       |  4 +
 AmberTools/test/rism1d/tip3p-kh/tip3p.xvv.save     |  4 +
 .../test/rism3d.periodic/1ahoa/erism.pme.out.save  | 16 ++--
 .../test/rism3d.periodic/4lzta/erism.pme.out.save  | 16 ++--
 test/rism3d/1ahoa/Run.1ahoa.pme                    |  5 +-
 test/rism3d/1ahoa/Run.msander                      | 79 ++++++++++++++++++
 test/rism3d/1ahoa/erism.pme.out.save               | 36 ++++----
 test/rism3d/4lzt/Run.4lzt.pme                      |  2 +-
 test/rism3d/4lzt/Run.msander                       | 74 +++++++++++++++++
 test/rism3d/4lzt/erism.out.save                    | 36 ++++----
 25 files changed, 450 insertions(+), 218 deletions(-)
```


