### PR TITLE
update to 21.10

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ export CXXFLAGS="${CXXFLAGS} -pthread"
 # duplicate symbols cause errors on GCC10+ and Clang 11+
 # see https://github.com/conda-forge/ambertools-feedstock/pull/50#issuecomment-756171906
 # This will get fixed upstream at some point...
-if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2109 )); then
+if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2110 )); then
     export CFLAGS="${CFLAGS:-} -fcommon"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "21.9" %}
+{% set version = "21.10" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://ambermd.org/bugfixes/AmberTools/21.0/update.10

```
*******> update.10

Author: Stephan Schott-Verdugo

Date: September 16, 2021

Programs: packmol-memgen

Description: 
             1) Adds missing extra_solvents.lib
             2) Fix 2LPG packing param
-------------------------------------------------------------------------------- 
.../packmol_memgen/data/extra_solvents.lib         | 789 +++++++++++++++++++++
.../packmol_memgen/packmol_memgen/data/memgen.parm |   2 +-
2 files changed, 790 insertions(+), 1 deletion(-)
```