### PR TITLE
add krb5 to both build and host so they can be merged

### DIFF
--- a/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.19'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.6.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.7.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.8.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -36,6 +36,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.19'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
@@ -38,6 +38,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -38,6 +38,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -38,6 +38,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.18'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -38,6 +38,8 @@ netcdf_fortran:
 - '4.5'
 numpy:
 - '1.19'
+openssl:
+- 1.1.1
 perl:
 - 5.26.2
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - perl
     - llvm-openmp  # [osx]
     - libgomp      # [linux and not aarch64]
-    - krb5
+    - openssl
   host:
     - python
     - setuptools
@@ -66,7 +66,7 @@ requirements:
     - libgomp      # [linux and not aarch64]
     - parmed 3.4.1
     - packmol
-    - krb5
+    - openssl
   run:
     - python
     - perl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - perl
     - llvm-openmp  # [osx]
     - libgomp      # [linux and not aarch64]
+    - krb5
   host:
     - python
     - setuptools
@@ -65,6 +66,7 @@ requirements:
     - libgomp      # [linux and not aarch64]
     - parmed 3.4.1
     - packmol
+    - krb5
   run:
     - python
     - perl


### PR DESCRIPTION
Last PR was merged after passing the tests, but in the interim a new `krb5` was added, and now `build` and `host` cannot be merged. Adding it explicitly to both should fix it. Let's see!

The error was (for searchability): 

```
ValueError: Incompatible component merge:
  - 'h48eae69_1'
  - 'hcc1bbae_1'
```

These hashes can be found [here](https://anaconda.org/conda-forge/krb5/files). To debug this kind of problem, one can go to the repodata HTML render and search for the hash in the corresponding subdir. For example, `osx-64` is [here](https://conda.anaconda.org/conda-forge/osx-64/).