### PR TITLE
Build AmberTools 22.5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ export CXXFLAGS="${CXXFLAGS} -pthread"
 # duplicate symbols cause errors on GCC10+ and Clang 11+
 # see https://github.com/conda-forge/ambertools-feedstock/pull/50#issuecomment-756171906
 # This will get fixed upstream at some point...
-if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2204 )); then
+if (( $(printf "%02d%02d" ${PKG_VERSION//./ }) <= 2205 )); then
     export CFLAGS="${CFLAGS:-} -fcommon"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "AmberTools" %}
 # Versioning scheme uses AmberTools major release as MAJOR version number, patch level as MINOR version number
 # Update the MINOR version number as new patch releases come out
-{% set version = "22.4" %}
+{% set version = "22.5" %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +16,7 @@ source:
     - patches/do_not_vendor_packmol.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or py2k or ppc64le or aarch64]
   # Some binaries (e.g. nab) hardcode the path to the compiler in BUILD_PREFIX
   # which does not get replaced and causes errors on runtime
@@ -91,7 +91,7 @@ requirements:
     - readline
     - llvm-openmp  # [osx]
     - libgomp      # [linux and not aarch64]
-    - parmed >=3.4.1,<4.0.0a
+    - parmed >=3.4.1,<5.0.0a
     - packmol
   run_constrained:
     - ambermini ==9999999999

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ requirements:
     - readline
     - llvm-openmp  # [osx]
     - libgomp      # [linux and not aarch64]
-    - parmed 3.4.1
+    - parmed 4.1.0
     - packmol
     - openssl
     # WORKAROUND


### PR DESCRIPTION
This update fixes compatibility of AmberTools 22 with ParmEd >=4.0.0

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closing #105 

<!--
Please add any other relevant info below:
-->
